### PR TITLE
Feature/remove blank link from end of menv output

### DIFF
--- a/src/menv.js
+++ b/src/menv.js
@@ -44,7 +44,7 @@ function produceEvalOutput(config) {
     config.suffix
   }${config.comment} Run this command to configure your shell\n${
     config.comment
-  } ${config.cmd}\n`
+  } ${config.cmd}`
 }
 
 function getShell(shell) {


### PR DESCRIPTION
The extra blank line at the end of the output was causing errors in powershell.  These errors did not cause errors with the actual command.