### PR TITLE
CLI authentication via keycloak token

### DIFF
--- a/src/mrefreshauth.js
+++ b/src/mrefreshauth.js
@@ -63,11 +63,11 @@ export const handler = async (context, argv) => {
   {
     requestConfig = {
       method: 'POST',
-      url: authConfig.url || 'https://maana.auth0.com/oauth/token',
+      url: authConfig.url,
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
         grant_type: 'refresh_token',
-        client_id: authConfig.id || 'CAivZr2hUDeHpRQZFhMSZLJdjORd7gjk',
+        client_id: authConfig.id,
         refresh_token: authConfig.refresh_token
       })
     }
@@ -76,8 +76,8 @@ export const handler = async (context, argv) => {
   else if (authConfig.IDP === 'keycloak'){
     var form = {
       grant_type: 'refresh_token',
-      client_id: authConfig.clientId,
-      refresh_token: authConfig.refreshToken
+      client_id: authConfig.id,
+      refresh_token: authConfig.refresh_token
     };
     
     var formData = querystring.stringify(form);
@@ -87,7 +87,7 @@ export const handler = async (context, argv) => {
         'Content-Length': contentLength,
         'Content-Type': 'application/x-www-form-urlencoded'
       },
-      uri: authConfig.tokenUrl,
+      uri: `${authConfig.url}/auth/realms/${authConfig.realm}/protocol/openid-connect/userinfo`,
       body: formData,
       method: 'POST'
     }
@@ -108,7 +108,8 @@ export const handler = async (context, argv) => {
       authConfig.expires_at = Date.now() + authInfo.expires_in * 1000
       authConfig.access_token = authInfo.access_token
     } else if(authInfo.IDP === 'keycloak') {
-      authConfig.expires_at = Date.now() + authInfo.tokenParsed.exp * 1000
+      // Account for different token format from keycloak.
+      authConfig.expires_at = authInfo.tokenParsed.exp * 1000
       authConfig.access_token = authInfo.token
     }
 

--- a/src/mrefreshauth.js
+++ b/src/mrefreshauth.js
@@ -73,7 +73,7 @@ export const handler = async (context, argv) => {
     }
   }
   // Keycloak request
-  else if(authConfig.IDP === 'keycloak'){
+  else if (authConfig.IDP === 'keycloak'){
     var form = {
       grant_type: 'refresh_token',
       client_id: authConfig.clientId,
@@ -91,7 +91,7 @@ export const handler = async (context, argv) => {
       body: formData,
       method: 'POST'
     }
-  }else{
+  } else{
     console.log(
       chalk.red(
         `✘ Cannot refresh token from unsupported IDP: ${authConfig.IDP}`
@@ -103,8 +103,14 @@ export const handler = async (context, argv) => {
     let response = await request(requestConfig)
     // build the auth information
     let authInfo = JSON.parse(response)
-    authConfig.expires_at = Date.now() + authInfo.expires_in * 1000
-    authConfig.access_token = authInfo.access_token
+
+    if (!authInfo.IDP || authInfo.IDP === 'auth0'){
+      authConfig.expires_at = Date.now() + authInfo.expires_in * 1000
+      authConfig.access_token = authInfo.access_token
+    } else if(authInfo.IDP === 'keycloak') {
+      authConfig.expires_at = Date.now() + authInfo.tokenParsed.exp * 1000
+      authConfig.access_token = authInfo.token
+    }
 
     // add auth information to the cofig and save it
     maanaOptions.auth = Buffer.from(JSON.stringify(authConfig)).toString(

--- a/src/msignin.js
+++ b/src/msignin.js
@@ -88,15 +88,13 @@ export const handler = async (context, argv) => {
     // Send a request to the userinfo endpoint on keycloak.
     // This ensures the token received is valid -- not necessarily of our origin, i.e., this could be spoofed (as could Auth0). 
     // Regardless, this is acceptable (for either IDP flow) since all requests must authenticate through API against auth provider.
-    let token = (!authConfig.token.startsWith('Bearer ')) 
-      ?'Bearer ' + authConfig.token
+    let token = (!authConfig.access_token.startsWith('Bearer ')) 
+      ?'Bearer ' + authConfig.access_token
       : token
-
-    let userInfoUrl = authConfig.userInfoUrl
 
     requestConfig = {
         method: 'GET',
-        url: userInfoUrl, 
+        url: `${authConfig.url}/auth/realms/${authConfig.realm}/protocol/openid-connect/userinfo`, 
         headers: {
             Authorization: token
         },
@@ -125,11 +123,7 @@ export const handler = async (context, argv) => {
     // For keycloak, use what's in the authconfig that we validated.
     else if(authConfig.IDP === 'keycloak'){
       authInfo = authConfig
-      // Give alias for token to match Auth0 for prosperity.
-      authConfig.access_token = authConfig.token
-      authInfo.expires_at = Date.now() + authInfo.tokenParsed.exp * 1000
-      authInfo.url = authConfig.tokenUrl
-      authInfo.id = authConfig.clientId
+      // Expiry, url, and id are expected in incoming base64 package. 
     }
     
     // add auth information to the cofig and save it


### PR DESCRIPTION
This will handle validation and passing of keycloak token to API. To retain same behavior under keycloak as Auth0, it is expected that "userInfoUrl","tokenUrl" and "IDP" (keycloak or Auth0) are present in the base64 token. 

Additional logging is provided in msignin that indicates which auth provider is being used to indicate that auth-specific configuration prior to "signin" was correct.