### PR TITLE
CLI authentication via keycloak token - DEVELOP

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "n3": "^1.0.0-beta.2",
     "papaparse": "^4.6.0",
     "parse-github-url": "^1.0.2",
+    "querystring": "^0.2.0",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.5",
     "rimraf": "^2.6.2",

--- a/src/mrefreshauth.js
+++ b/src/mrefreshauth.js
@@ -55,11 +55,16 @@ export const handler = async (context, argv) => {
     Buffer.from(maanaOptions.auth, 'base64').toString()
   )
 
-  // request the access token
+  // Define enum for supported IDPs.
+  const IdentityProvider = Object.freeze({
+    Auth0: 'auth0',
+    KeyCloak: 'keycloak'
+  })
+
   let requestConfig
   
   // Auth0 request
-  if(!authConfig.IDP || authConfig.IDP === 'auth0')
+  if(!authConfig.IDP || authConfig.IDP === IdentityProvider.Auth0)
   {
     requestConfig = {
       method: 'POST',
@@ -73,7 +78,7 @@ export const handler = async (context, argv) => {
     }
   }
   // Keycloak request
-  else if (authConfig.IDP === 'keycloak'){
+  else if (authConfig.IDP === IdentityProvider.KeyCloak){
     var form = {
       grant_type: 'refresh_token',
       client_id: authConfig.id,
@@ -104,10 +109,10 @@ export const handler = async (context, argv) => {
     // build the auth information
     let authInfo = JSON.parse(response)
 
-    if (!authInfo.IDP || authInfo.IDP === 'auth0'){
+    if (!authInfo.IDP || authInfo.IDP === IdentityProvider.Auth0){
       authConfig.expires_at = Date.now() + authInfo.expires_in * 1000
       authConfig.access_token = authInfo.access_token
-    } else if(authInfo.IDP === 'keycloak') {
+    } else if(authInfo.IDP === IdentityProvider.KeyCloak) {
       // Account for different token format from keycloak.
       authConfig.expires_at = authInfo.tokenParsed.exp * 1000
       authConfig.access_token = authInfo.token

--- a/src/mrefreshauth.js
+++ b/src/mrefreshauth.js
@@ -1,7 +1,6 @@
 import chalk from 'chalk'
 import request from 'request-promise-native'
 import { getGraphQLConfig } from 'graphql-config'
-import { IdentityProvider } from './util'
 var querystring = require('querystring');
 
 // Plugin boilerplate

--- a/src/mrefreshauth.js
+++ b/src/mrefreshauth.js
@@ -63,11 +63,11 @@ export const handler = async (context, argv) => {
   {
     requestConfig = {
       method: 'POST',
-      url: authConfig.url || 'https://maana.auth0.com/oauth/token',
+      url: authConfig.url,
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
         grant_type: 'refresh_token',
-        client_id: authConfig.id || 'CAivZr2hUDeHpRQZFhMSZLJdjORd7gjk',
+        client_id: authConfig.id,
         refresh_token: authConfig.refresh_token
       })
     }
@@ -76,8 +76,8 @@ export const handler = async (context, argv) => {
   else if (authConfig.IDP === 'keycloak'){
     var form = {
       grant_type: 'refresh_token',
-      client_id: authConfig.clientId,
-      refresh_token: authConfig.refreshToken
+      client_id: authConfig.id,
+      refresh_token: authConfig.refresh_token
     };
     
     var formData = querystring.stringify(form);
@@ -87,7 +87,7 @@ export const handler = async (context, argv) => {
         'Content-Length': contentLength,
         'Content-Type': 'application/x-www-form-urlencoded'
       },
-      uri: authConfig.tokenUrl,
+      uri: `${authConfig.url}/auth/realms/${authConfig.realm}/protocol/openid-connect/userinfo`,
       body: formData,
       method: 'POST'
     }
@@ -108,7 +108,8 @@ export const handler = async (context, argv) => {
       authConfig.expires_at = Date.now() + authInfo.expires_in * 1000
       authConfig.access_token = authInfo.access_token
     } else if(authInfo.IDP === 'keycloak') {
-      authConfig.expires_at = Date.now() + authInfo.tokenParsed.exp * 1000
+      // Account for different token format from keycloak.
+      authConfig.expires_at = authInfo.tokenParsed.exp * 1000
       authConfig.access_token = authInfo.token
     }
 

--- a/src/mrefreshauth.js
+++ b/src/mrefreshauth.js
@@ -56,47 +56,24 @@ export const handler = async (context, argv) => {
     Buffer.from(maanaOptions.auth, 'base64').toString()
   )
 
-  let requestConfig
-  
-  // Auth0 request
-  if(!authConfig.IDP || authConfig.IDP === IdentityProvider.Auth0)
-  {
-    requestConfig = {
-      method: 'POST',
-      url: authConfig.url,
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        grant_type: 'refresh_token',
-        client_id: authConfig.id,
-        refresh_token: authConfig.refresh_token
-      })
-    }
+  // This is a generic OAuth request and will
+  // work for Auth0 or Keycloak.
+  let requestConfig = {
+    grant_type: 'refresh_token',
+    client_id: authConfig.id,
+    refresh_token: authConfig.refresh_token
   }
-  // Keycloak request
-  else if (authConfig.IDP === IdentityProvider.KeyCloak){
-    var form = {
-      grant_type: 'refresh_token',
-      client_id: authConfig.id,
-      refresh_token: authConfig.refresh_token
-    }
-    
-    var formData = querystring.stringify(form);
-    var contentLength = formData.length;
-    requestConfig = {
-      headers: {
-        'Content-Length': contentLength,
-        'Content-Type': 'application/x-www-form-urlencoded'
-      },
-      uri: authConfig.url,
-      body: formData,
-      method: 'POST'
-    }
-  } else{
-    console.log(
-      chalk.red(
-        `✘ Cannot refresh token from unsupported IDP: ${authConfig.IDP}`
-      )
-    )
+
+  var formData = querystring.stringify(form);
+  var contentLength = formData.length;
+  requestConfig = {
+    headers: {
+      'Content-Length': contentLength,
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    uri: authConfig.url,
+    body: formData,
+    method: 'POST'
   }
 
   try {

--- a/src/mrefreshauth.js
+++ b/src/mrefreshauth.js
@@ -73,7 +73,7 @@ export const handler = async (context, argv) => {
     }
   }
   // Keycloak request
-  else if(authConfig.IDP === 'keycloak'){
+  else if (authConfig.IDP === 'keycloak'){
     var form = {
       grant_type: 'refresh_token',
       client_id: authConfig.clientId,
@@ -91,7 +91,7 @@ export const handler = async (context, argv) => {
       body: formData,
       method: 'POST'
     }
-  }else{
+  } else{
     console.log(
       chalk.red(
         `✘ Cannot refresh token from unsupported IDP: ${authConfig.IDP}`
@@ -103,8 +103,14 @@ export const handler = async (context, argv) => {
     let response = await request(requestConfig)
     // build the auth information
     let authInfo = JSON.parse(response)
-    authConfig.expires_at = Date.now() + authInfo.expires_in * 1000
-    authConfig.access_token = authInfo.access_token
+
+    if (!authInfo.IDP || authInfo.IDP === 'auth0'){
+      authConfig.expires_at = Date.now() + authInfo.expires_in * 1000
+      authConfig.access_token = authInfo.access_token
+    } else if(authInfo.IDP === 'keycloak') {
+      authConfig.expires_at = Date.now() + authInfo.tokenParsed.exp * 1000
+      authConfig.access_token = authInfo.token
+    }
 
     // add auth information to the cofig and save it
     maanaOptions.auth = Buffer.from(JSON.stringify(authConfig)).toString(

--- a/src/mrefreshauth.js
+++ b/src/mrefreshauth.js
@@ -78,7 +78,7 @@ export const handler = async (context, argv) => {
       grant_type: 'refresh_token',
       client_id: authConfig.id,
       refresh_token: authConfig.refresh_token
-    };
+    }
     
     var formData = querystring.stringify(form);
     var contentLength = formData.length;
@@ -87,7 +87,7 @@ export const handler = async (context, argv) => {
         'Content-Length': contentLength,
         'Content-Type': 'application/x-www-form-urlencoded'
       },
-      uri: `${authConfig.url}/auth/realms/${authConfig.realm}/protocol/openid-connect/userinfo`,
+      uri: authConfig.url,
       body: formData,
       method: 'POST'
     }
@@ -101,17 +101,11 @@ export const handler = async (context, argv) => {
 
   try {
     let response = await request(requestConfig)
+
     // build the auth information
     let authInfo = JSON.parse(response)
-
-    if (!authInfo.IDP || authInfo.IDP === IdentityProvider.Auth0){
-      authConfig.expires_at = Date.now() + authInfo.expires_in * 1000
-      authConfig.access_token = authInfo.access_token
-    } else if(authInfo.IDP === IdentityProvider.KeyCloak) {
-      // Account for different token format from keycloak.
-      authConfig.expires_at = authInfo.tokenParsed.exp * 1000
-      authConfig.access_token = authInfo.token
-    }
+    authConfig.expires_at = Date.now() + authInfo.expires_in * 1000
+    authConfig.access_token = authInfo.access_token
 
     // add auth information to the cofig and save it
     maanaOptions.auth = Buffer.from(JSON.stringify(authConfig)).toString(

--- a/src/mrefreshauth.js
+++ b/src/mrefreshauth.js
@@ -1,6 +1,7 @@
 import chalk from 'chalk'
 import request from 'request-promise-native'
 import { getGraphQLConfig } from 'graphql-config'
+import { IdentityProvider } from './util'
 var querystring = require('querystring');
 
 // Plugin boilerplate
@@ -54,12 +55,6 @@ export const handler = async (context, argv) => {
   let authConfig = JSON.parse(
     Buffer.from(maanaOptions.auth, 'base64').toString()
   )
-
-  // Define enum for supported IDPs.
-  const IdentityProvider = Object.freeze({
-    Auth0: 'auth0',
-    KeyCloak: 'keycloak'
-  })
 
   let requestConfig
   

--- a/src/msignin.js
+++ b/src/msignin.js
@@ -88,15 +88,13 @@ export const handler = async (context, argv) => {
     // Send a request to the userinfo endpoint on keycloak.
     // This ensures the token received is valid -- not necessarily of our origin, i.e., this could be spoofed (as could Auth0). 
     // Regardless, this is acceptable (for either IDP flow) since all requests must authenticate through API against auth provider.
-    let token = (!authConfig.token.startsWith('Bearer ')) 
-      ?'Bearer ' + authConfig.token
+    let token = (!authConfig.access_token.startsWith('Bearer ')) 
+      ?'Bearer ' + authConfig.access_token
       : token
-
-    let userInfoUrl = authConfig.userInfoUrl
 
     requestConfig = {
         method: 'GET',
-        url: userInfoUrl, 
+        url: `${authConfig.url}/auth/realms/${authConfig.realm}/protocol/openid-connect/userinfo`, 
         headers: {
             Authorization: token
         },
@@ -125,11 +123,7 @@ export const handler = async (context, argv) => {
     // For keycloak, use what's in the authconfig that we validated.
     else if(authConfig.IDP === 'keycloak'){
       authInfo = authConfig
-      // Give alias for token to match Auth0 for prosperity.
-      authConfig.access_token = authConfig.token
-      authInfo.expires_at = Date.now() + authInfo.tokenParsed.exp * 1000
-      authInfo.url = authConfig.tokenUrl
-      authInfo.id = authConfig.clientId
+      // Expiry, url, and id are expected in incoming base64 package. 
     }
     
     // add auth information to the cofig and save it

--- a/src/msignin.js
+++ b/src/msignin.js
@@ -1,7 +1,7 @@
 import chalk from 'chalk'
 import request from 'request-promise-native'
 import { getGraphQLConfig } from 'graphql-config'
-import { addHeadersToConfig } from './util'
+import { addHeadersToConfig, IdentityProvider } from './util'
 
 // Plugin boilerplate
 export const command = 'msignin [Authentication Token] [--project]'
@@ -62,12 +62,6 @@ export const handler = async (context, argv) => {
     }
     authConfig = JSON.parse(Buffer.from(authToken, 'base64').toString())
   }
-
-  // Define enum for supported IDPs.
-  const IdentityProvider = Object.freeze({
-    Auth0: 'auth0',
-    KeyCloak: 'keycloak'
-  })
 
   let requestConfig
 

--- a/src/msignin.js
+++ b/src/msignin.js
@@ -71,7 +71,7 @@ export const handler = async (context, argv) => {
   try {
     // Set auth info to Auth0 repsonse, containing token.
     if(!authConfig.IDP || authConfig.IDP === IdentityProvider.Auth0){
-      // Auth0 uses Authentication Code Flow and PKCE, exchanging code for full auth token.
+      // Auth0 uses Authentication Code Flow and PKCE.
       requestConfig = {
         method: 'POST',
         url: authConfig.url,
@@ -86,7 +86,7 @@ export const handler = async (context, argv) => {
       }
       console.log(chalk.green('✔ Auth provider configured as Auth0')) 
     }
-    // For keycloak, use what's in the authconfig that we validated.
+    // Keycloak uses Authentication Code Flow and PKCE.
     else if(authConfig.IDP === IdentityProvider.KeyCloak){
       var form = {
         grant_type: 'authorization_code',
@@ -117,8 +117,9 @@ export const handler = async (context, argv) => {
     authInfo.id = authConfig.id
 
     // If we have IDP persist this for refresh.
-    if (authConfig.IDP)
+    if (authConfig.IDP){
       authInfo.IDP = authConfig.IDP
+    }
 
     // add auth information to the cofig and save it
     maanaOptions.auth = Buffer.from(JSON.stringify(authInfo)).toString('base64')

--- a/src/msignin.js
+++ b/src/msignin.js
@@ -1,7 +1,7 @@
 import chalk from 'chalk'
 import request from 'request-promise-native'
 import { getGraphQLConfig } from 'graphql-config'
-import { addHeadersToConfig, IdentityProvider } from './util'
+import { addHeadersToConfig } from './util'
 const querystring = require('querystring');
 
 // Plugin boilerplate

--- a/src/util.js
+++ b/src/util.js
@@ -188,14 +188,3 @@ export const getSchema = config => {
   const schemaContents = fs.readFileSync(schemaPath).toString()
   return buildASTSchema(parse(schemaContents))
 }
-
-
-//
-// Auth utilities
-//
-
-// Enum for supported IDPs.
-export const IdentityProvider = Object.freeze({
-  Auth0: 'auth0',
-  KeyCloak: 'keycloak'
-})

--- a/src/util.js
+++ b/src/util.js
@@ -188,3 +188,14 @@ export const getSchema = config => {
   const schemaContents = fs.readFileSync(schemaPath).toString()
   return buildASTSchema(parse(schemaContents))
 }
+
+
+//
+// Auth utilities
+//
+
+// Enum for supported IDPs.
+export const IdentityProvider = Object.freeze({
+  Auth0: 'auth0',
+  KeyCloak: 'keycloak'
+})


### PR DESCRIPTION
This will handle validation and passing of keycloak token to API. To retain same behavior under keycloak as Auth0, it is expected that "userInfoUrl","tokenUrl" and "IDP" (keycloak or Auth0) are present in the base64 token.

Additional logging is provided in msignin that indicates which auth provider is being used to indicate that auth-specific configuration prior to "signin" was correct.