### PR TITLE
Support new k8s 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-cli-maana",
-  "version": "3.2.12-beta",
+  "version": "3.2.12",
   "description": "Maana plugin for graphql-cli",
   "repository": {
     "type": "git",

--- a/src/scripts/deployment-service.yaml
+++ b/src/scripts/deployment-service.yaml
@@ -13,7 +13,7 @@ items:
       targetPort: {{PORT}}
     selector:
       service: "{{SERVICE_NAME}}"
-- apiVersion: extensions/v1beta1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     labels:
@@ -22,6 +22,9 @@ items:
   spec:
     replicas: {{REPLICAS}}
     strategy: {}
+    selector:
+      matchLabels:
+        service: "{{SERVICE_NAME}}"
     template:
       metadata:
         labels:


### PR DESCRIPTION
3.2.12 - support k8s 1.15+ (and later, after deprecation of beta deployment support) - support new API version for deployments

This superseded https://github.com/maana-io/q-cli/pull/75 - pretty much same change but follows the process (PRs against develop, only PR to master from develop)